### PR TITLE
Move PCM code to fix header.

### DIFF
--- a/sub/core.asm
+++ b/sub/core.asm
@@ -34,8 +34,8 @@
 	include	"sub/call_table.asm"
 	include	"sub/interrupt.asm"
 	include	"sub/module.asm"
-	include	"sub/pcm.asm"
 	include	"sub/main.asm"
+	include	"sub/pcm.asm"
 	
 ; ----------------------------------------------------------------------
 ; Padding


### PR DESCRIPTION
The 'SEGA' string moved out of its usual spot in the compressed data, breaking my 'Super Sonic & Hyper Sonic in Sonic 1' ROM-hack.